### PR TITLE
doc(securing-your-webhooks): show test values

### DIFF
--- a/content/webhooks-and-events/webhooks/securing-your-webhooks.md
+++ b/content/webhooks-and-events/webhooks/securing-your-webhooks.md
@@ -64,6 +64,23 @@ Your language and server implementations may differ from the following examples.
 
 - Using a plain `==` operator is **not advised**. A method like [`secure_compare`][secure_compare] performs a "constant time" string comparison, which helps mitigate certain timing attacks against regular equality operators.
 
+### Test values
+
+Regardless of programming language, these values can be used to know that the implementation is correct.
+
+```yaml
+Secret:          It's a Secret to Everybody
+Payload:         Hello, World!
+
+Algorithm:       SHA-256
+Signature:       757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17
+X-Hub-Signature: sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17
+
+Algorithm:       SHA-1
+Signature:       01dc10d0c83e72ed246219cdd91669667fe2ca59
+X-Hub-Signature: sha1=01dc10d0c83e72ed246219cdd91669667fe2ca59
+```
+
 ### Ruby example
 
 For example, you can define the following `verify_signature` function:


### PR DESCRIPTION
### Why:

It's always good to have test values to know that a subtle difference in implementation isn't causing buggy behavior.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Adding test values.

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
