### PR TITLE
sec(securing-your-webhooks): use constant time comparator

### DIFF
--- a/content/webhooks-and-events/webhooks/securing-your-webhooks.md
+++ b/content/webhooks-and-events/webhooks/securing-your-webhooks.md
@@ -62,7 +62,7 @@ Your language and server implementations may differ from the following examples.
 
 - No matter which implementation you use, the hash signature starts with `sha256=`, using the key of your secret token and your payload body.
 
-- Using a plain `==` operator is **not advised**. A method like [`secure_compare`][secure_compare] performs a "constant time" string comparison, which helps mitigate certain timing attacks against regular equality operators.
+- Using a plain `==` operator is **not advised**. A method like [`secure_compare`][secure_compare] or [`crypto.timingSafeEqual`][timingSafeEqual] performs a "constant time" string comparison, which helps mitigate certain timing attacks against regular equality operators, or regular loops in JIT-optimized languages.
 
 ### Ruby example
 
@@ -126,7 +126,9 @@ const verify_signature = (req: Request) => {
     .createHmac("sha256", WEBHOOK_SECRET)
     .update(JSON.stringify(req.body))
     .digest("hex");
-  return `sha256=${signature}` === req.headers.get("x-hub-signature-256");
+  let trusted = Buffer.from(`sha256=${signature}`, 'ascii');
+  let untrusted =  Buffer.from(req.headers.get("x-hub-signature-256"), 'ascii');
+  return crypto.timingSafeEqual(trusted, untrusted);
 };
 
 const handleWebhook = (req: Request, res: Response) => {
@@ -139,3 +141,4 @@ const handleWebhook = (req: Request, res: Response) => {
 ```
 
 [secure_compare]: https://rubydoc.info/github/rack/rack/main/Rack/Utils:secure_compare
+[timingSafeEqual]: https://nodejs.org/api/crypto.html#cryptotimingsafeequala-b


### PR DESCRIPTION
Despite noting the security vulnerability above, this gives a poor typescript example that is vulnerable in the exact way described - and a variety of node modules have copied this example exactly, inheriting the vulnerability.

### Why:

Security.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Using `crypto.timingSafeEqual()`.

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.
  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
