### PR TITLE
doc(securing-your-webhooks): add standard JavaScript example

### DIFF
--- a/content/webhooks-and-events/webhooks/securing-your-webhooks.md
+++ b/content/webhooks-and-events/webhooks/securing-your-webhooks.md
@@ -112,6 +112,57 @@ def verify_signature(payload_body, secret_token, signature_header):
         raise HTTPException(status_code=403, detail="Request signatures didn't match!")
 ```
 
+### JavaScript example
+
+For example, you can define the following `verifySignature` function and call it in any JavaScript environment - Node.js, Bun, Deno, etc - when you receive a webhook payload:
+
+```javascript
+let encoder = new TextEncoder();
+
+async function verifySignature(secret, header, payload) {
+    let parts = header.split("=");
+    let sigHex = parts[1];
+
+    let algorithm = { name: "HMAC", hash: { name: 'SHA-256' } };
+
+    let keyBytes = encoder.encode(secret);
+    let extractable = false;
+    let key = await crypto.subtle.importKey(
+        "raw",
+        keyBytes,
+        algorithm,
+        extractable,
+        [ "sign", "verify" ],
+    );
+
+    let sigBytes = hexToBytes(sigHex);
+    let dataBytes = encoder.encode(payload);
+    let equal = await crypto.subtle.verify(
+        algorithm.name,
+        key,
+        sigBytes,
+        dataBytes,
+    );
+
+    return equal;
+}
+
+function hexToBytes(hex) {
+    let len = hex.length / 2;
+    let bytes = new Uint8Array(len);
+
+    let index = 0;
+    for (let i = 0; i < hex.length; i += 2) {
+        let c = hex.slice(i, i + 2);
+        let b = parseInt(c, 16);
+        bytes[index] = b;
+        index += 1;
+    }
+
+    return bytes;
+}
+```
+
 ### Typescript example
 
 For example, you can define the following `verify_signature` function and call it when you receive a webhook payload:


### PR DESCRIPTION
Adds a JavaScript example that is secure, and follows the WebCrypto standards to work in all JavaScript environments.

### Why:

To add a cross-runtime JavaScript example

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Adds a cross-runtime JavaScript example

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
